### PR TITLE
Tracing sentry_sdk 0.7.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ associate_commits:
 	sentry-cli releases -o $(SENTRY_ORG) -p $(SENTRY_PROJECT) set-commits --auto $(VERSION)
 
 run_flask:
-	VERSION=$(VERSION) FLASK_APP=app.py flask run -p 3001
+	VERSION=$(VERSION) FLASK_APP=app.py flask run -p 5001

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To show how Sentry works in an example web app that uses Flask
 - `app.py` has multiple endpoints for showing different ways that errors are handled
 - Sentry Release cycle covered in `Makefile`
 
-## Initial Setup & Run
+## Setup
 1.
 ```
 pip install -r ./requirements.txt
@@ -15,10 +15,24 @@ pip install -r ./requirements.txt
 1. Configure Sentry with your `DSN key` in app.py
 2. Configure sentry-cli (is for creating Sentry releases) with your `SENTRY_AUTH_TOKEN` in Makefile or run `export SENTRY_AUTH_TOKEN=<your_auth_token>`. Do the same for `SENTRY_ORG` and `SENTRY_PROJECT`
 3. Check your Github repo is integrated into your Sentry organization.
-4. run make, which (Makefile) creates a Sentry release and runs Flask
+
+## Run
+1. run make, which (Makefile) creates a Sentry release and runs Flask
 ```
 make deploy
 ```
 
 ## GIF
 ![Alt Text](flask-demo.gif)
+
+## Changelog
+^0.7.13 for Tracing integration
+
+## optional
+Create a virtualenv for your Sentry Flask project
+```bash
+virtualenv $HOME/my_virtualenvs/sentry_flask
+source $HOME/my_virtualenvs/sentry_flask/bin/activate
+pip install sentry_sdk==0.7.13
+pip freeze...?
+```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,5 @@ Create a virtualenv for your Sentry Flask project
 ```bash
 virtualenv $HOME/my_virtualenvs/sentry_flask
 source $HOME/my_virtualenvs/sentry_flask/bin/activate
-pip install sentry_sdk==0.7.13
-pip freeze...?
+pip install -r ./requirements.txt
 ```

--- a/app.py
+++ b/app.py
@@ -46,20 +46,18 @@ def process_order(cart):
             print 'Success: ' + item['id'] + ' was purchased, remaining stock is ' + str(tempInventory[item['id']])
     Inventory = tempInventory 
 
+# trace Id (transaction) is set by sentry_sdk as of version 0.7.13
 @app.before_request
 def sentry_event_context():
-
     if (request.data):
         order = json.loads(request.data)
         with sentry_sdk.configure_scope() as scope:
                 scope.user = { "email" : order["email"] }
         
-    # transactionId = request.headers.get('X-Transaction-ID')
     sessionId = request.headers.get('X-Session-ID')
     global Inventory
 
     with sentry_sdk.configure_scope() as scope:
-        # scope.set_tag("transaction_id", transactionId)
         scope.set_tag("session_id", sessionId)
         scope.set_extra("inventory", Inventory)
 

--- a/app.py
+++ b/app.py
@@ -59,8 +59,8 @@ def sentry_event_context():
     global Inventory
 
     with sentry_sdk.configure_scope() as scope:
-        scope.set_tag("transaction-id", transactionId)
-        scope.set_tag("session-id", sessionId)
+        scope.set_tag("transaction_id", transactionId)
+        scope.set_tag("session_id", sessionId)
         scope.set_extra("inventory", Inventory)
 
 @app.route('/checkout', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -54,12 +54,12 @@ def sentry_event_context():
         with sentry_sdk.configure_scope() as scope:
                 scope.user = { "email" : order["email"] }
         
-    transactionId = request.headers.get('X-Transaction-ID')
+    # transactionId = request.headers.get('X-Transaction-ID')
     sessionId = request.headers.get('X-Session-ID')
     global Inventory
 
     with sentry_sdk.configure_scope() as scope:
-        scope.set_tag("transaction_id", transactionId)
+        # scope.set_tag("transaction_id", transactionId)
         scope.set_tag("session_id", sessionId)
         scope.set_extra("inventory", Inventory)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 flask==1.0.2
-sentry_sdk==0.7.10
+sentry_sdk==0.7.13
 flask-cors==3.0.7


### PR DESCRIPTION
Deleted this code, don't need it anymore:
```python   
 transactionId = request.headers.get('X-Transaction-ID')
 with sentry_sdk.configure_scope() as scope:
     scope.set_tag("transaction-id", transactionId)
```
because sentry_sdk==0.7.13 will set it for us.

### How
- It comes in the request Header as `sentry-trace: 00-09ba66c456e048a6bcca7a1cdcd8ff2f-9afe04d85bf6576a-00`
- `sentry-trace` is "00-" + `trace` + "-" + `trace.span` + "-00"

### Integration (React Tracing)
https://github.com/sentry-demos/react/pull/66